### PR TITLE
 Allow the manual specification of cert path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,22 @@ It's a simple ruby script that automates LetsEncrypt certificate injection
 
 Usually, you'd run this after your `certbot` renewal as part of your `--post-hook`, allowing you to automatically inject the new key and cert chain into AdGuardHome's YAML config file (example below).
 
-### Usage
+### Recommended:Automatic mode (only works with certbot)
 There are only two options, but both are required:
 ```
 Usage: ./adguard_letsencrypt.rb [options]
     -c, --config CONFIGFILE          Path to the AdGuardHome config file
     -d, --domain DOMAIN              Domain name for cert/key
+    
+```
+### Manual mode (can work with any ACMEv2 client)
+The full path to the fullchain file and privatekey must be specified:
+```
+Usage: ./adguard_letsencrypt.rb [options]
+    -c, --config CONFIGFILE          Path to the AdGuardHome config file
+    -k, --privkey PATH               Path to the private key file
+    -f, --fullchain PATH             Path to the fullchain file
+    
 ```
 
 ### Example usage with a `certbot` post hook

--- a/README.md
+++ b/README.md
@@ -25,5 +25,5 @@ Usage: ./adguard_letsencrypt.rb [options]
 ### Example usage with a `certbot` post hook
 Ideally, the chained commands would end up in a script to be passed as the single `--post-hook` 'command' to be run, but I've chained all three here to demonstrate the usual workflow:
 ``` bash
-certbot renew --post-hook '/path/to/AdGuardHome -s stop ; /path/to/adguard_letsencrypt.rb -c /path/to/AdGuardHome.yaml -d yoursite.com ; /path/to/AdGuardHome -s start'
+certbot renew --post-hook 'systemctl stop AdGuardHome ; /path/to/adguard_letsencrypt.rb -c /path/to/AdGuardHome.yaml -d yoursite.com ; systemctl start AdGuardHome'
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ It's a simple ruby script that automates LetsEncrypt certificate injection
 
 Usually, you'd run this after your `certbot` renewal as part of your `--post-hook`, allowing you to automatically inject the new key and cert chain into AdGuardHome's YAML config file (example below).
 
-### Recommended:Automatic mode (only works with certbot)
+### Recommended: Automatic mode (only works with certbot)
 There are only two options, but both are required:
 ```
 Usage: ./adguard_letsencrypt.rb [options]

--- a/adguardhome_letsencrypt.rb
+++ b/adguardhome_letsencrypt.rb
@@ -70,7 +70,7 @@ if options['keypath'].nil? || options['fullchainpath'].nil?
   new_cert = File.open("#{le_cert_path}/fullchain.pem").read.chop
 else
   new_key = File.open("#{keypath}").read.chop
-  new_cert = File.open("#{fullchainpath}"}.read.chop
+  new_cert = File.open("#{fullchainpath}").read.chop
 end
 
 # First, let's verify the new cert/key are actually different


### PR DESCRIPTION
Add a manual mode that allows you to specify the path to the fullchain and private key files.